### PR TITLE
[Fix] : header값이 origin server로 넘어가지 않는 문제 수정

### DIFF
--- a/app/earlybuddy/lib/main.dart
+++ b/app/earlybuddy/lib/main.dart
@@ -10,7 +10,7 @@ void main() async {
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   widgetsBinding = await PrepareRoot.setup(
     widgetsBinding: widgetsBinding,
-    dev: false,
+    dev: true,
   );
 
   await NotificationManager.initialize(

--- a/core/network/features/lib/sources/request_impl/add_schedule_request.dart
+++ b/core/network/features/lib/sources/request_impl/add_schedule_request.dart
@@ -14,7 +14,7 @@ final class AddScheduleRequest {
     return ApiRequest(
       path: '/schedule/create',
       method: HTTPMethod.post,
-      headers: {"access_token": accessToken},
+      headers: {"access-token": accessToken},
       requestData: requrestData,
     );
   }
@@ -27,7 +27,7 @@ final class AddScheduleRequest {
     return ApiRequest(
       path: '/schedule/update',
       method: HTTPMethod.patch,
-      headers: {"access_token": accessToken},
+      headers: {"access-token": accessToken},
       requestData: {
         "scheduleInfo": scheduleMap,
         "pathInfo": pathMap,
@@ -41,7 +41,7 @@ final class AddScheduleRequest {
   }) {
     final Map<String, String> query = {"schedule_id": scheduleID};
     const path = '/schedule/delete';
-    final header = {"access_token": accessToken};
+    final header = {"access-token": accessToken};
 
     return ApiRequest(
       path: path,

--- a/core/network/features/lib/sources/request_impl/auth_request.dart
+++ b/core/network/features/lib/sources/request_impl/auth_request.dart
@@ -65,7 +65,7 @@ final class AuthRequest {
     required String accessToken,
   }) {
     const path = '/auth/delete_user';
-    final headers = {'access_token': accessToken};
+    final headers = {'access-token': accessToken};
 
     return ApiRequest<EmptyDTO>(
       path: path,

--- a/core/network/features/lib/sources/request_impl/eb_token_request.dart
+++ b/core/network/features/lib/sources/request_impl/eb_token_request.dart
@@ -10,7 +10,7 @@ final class EBTokenRequest {
     return ApiRequest(
       path: path,
       method: HTTPMethod.get,
-      headers: {"refresh_token": refreshToken},
+      headers: {"refresh-token": refreshToken},
       converter: converter,
     );
   }

--- a/core/network/features/lib/sources/request_impl/home_request.dart
+++ b/core/network/features/lib/sources/request_impl/home_request.dart
@@ -7,7 +7,7 @@ final class HomeRequest {
     const path = "/home/get_all_schedules";
     SchedulePathListDTO converter(dynamic responseData) =>
         SchedulePathListDTO.fromJson(responseData);
-    final header = {"access_token": accessToken};
+    final header = {"access-token": accessToken};
 
     return ApiRequest(
       path: path,

--- a/core/network/features/lib/sources/request_impl/menu/noti_status_request.dart
+++ b/core/network/features/lib/sources/request_impl/menu/noti_status_request.dart
@@ -27,7 +27,7 @@ final class NotiStatusRequest {
   }) {
     const path = "$prefixPath/enable";
     final query = {"user_email": userEmail};
-    final header = {"fcm_token": fcmToken};
+    final header = {"fcm-token": fcmToken};
 
     return ApiRequest(
       path: path,

--- a/core/network/features/lib/sources/request_impl/request_impl.dart
+++ b/core/network/features/lib/sources/request_impl/request_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:eb_model/dto.dart';
 import 'package:eb_network/sources/service/service.dart';
 import 'package:eb_network_interface/eb_network_interface.dart';


### PR DESCRIPTION
- cloudflare dns, proxy mode 사용시 header값이 origin server로 넘어가지 않는 문제 수정
- 네트워크 모듈 request 작성시 header이름을 '_' -> '-' 변경
ex) access_token -> access-token